### PR TITLE
docs: fix typo and rdkit install

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# RXN chemisttry utilities package
+# RXN chemistry utilities package
 
 [![Actions tests](https://github.com/rxn4chemistry/rxn-chemutils/actions/workflows/tests.yaml/badge.svg)](https://github.com/rxn4chemistry/rxn-chemutils/actions)
 
@@ -32,5 +32,5 @@ The `RDKit` dependency is not installed automatically and can be installed via C
 conda install -c conda-forge rdkit
 
 # Install RDKit from Pypi
-pip install rdkit-pypi
+pip install rdkit
 ```

--- a/README.md
+++ b/README.md
@@ -33,4 +33,6 @@ conda install -c conda-forge rdkit
 
 # Install RDKit from Pypi
 pip install rdkit
+# for Python<3.7
+# pip install rdkit-pypi
 ```


### PR DESCRIPTION
Updated rdkit to install the new wheels from the official rdkit-maintained repo.