### PR TITLE
Different rdkit extras dependencies depending on the Python version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,8 @@ rdkit =
     # install RDKit. This is not as a setup dependency in order not to install it
     # in downstream packages and avoid potential conflicts with the conda
     # installation of RDKit
-    rdkit-pypi>=2021.3.2
+    rdkit-pypi>=2021.3.2 ; python_version<"3.7"
+    rdkit>=2022.3.4 ; python_version>="3.7"
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
FYI @drugilsberg 

Tested and works as expected in new conda environments with Python versions 3.6 (-> `rdkit-pypi`) and 3.7 and 3.9 (-> `rdkit`)